### PR TITLE
feat: Add Textarea component to CardAddForm

### DIFF
--- a/src/app/CardAddForm.tsx
+++ b/src/app/CardAddForm.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 import { AddNotes } from '@/const/ankiActions';
 import { RequestBuilder } from '@/lib/fetchUtils';
 import { useCounterStore } from '@/provider/result-provider';
+import { Textarea } from '@/components/ui/textarea';
 
 export default function CardAddForm() {
 
@@ -97,7 +98,7 @@ export default function CardAddForm() {
                         <FormItem>
                             <FormLabel>Back</FormLabel>
                             <FormControl>
-                                <Input placeholder="back" {...field} />
+                                <Textarea placeholder="back" {...field} />
                             </FormControl>
                             <FormMessage />
                         </FormItem>


### PR DESCRIPTION
This commit adds the `Textarea` component to the `CardAddForm` in `src/app/CardAddForm.tsx`. The `Textarea` component is imported from `@/components/ui/textarea` and is used to replace the existing `Input` component for the "Back" field in the form.

This change improves the user experience by providing a larger input area for entering the back side of the flashcard.